### PR TITLE
fix: restore PlanMyPeak auth for rewritten production portal

### DIFF
--- a/openspec/changes/fix-planmypeak-prod-auth-validation/.openspec.yaml
+++ b/openspec/changes/fix-planmypeak-prod-auth-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/fix-planmypeak-prod-auth-validation/design.md
+++ b/openspec/changes/fix-planmypeak-prod-auth-validation/design.md
@@ -1,0 +1,90 @@
+## Context
+
+PlanMyPeak was rewritten (Supabase-auth Next.js web app + separate Fastify API under `/api/backend`) and re-hosted at `https://portal.planmypeak.com/`. The extension's PlanMyPeak auth layer still assumes the old world:
+
+- Production app host `planmypeak.com`; production Supabase `https://yqaskiwzyhhovthbvmqq.supabase.co`.
+- `mainWorldInterceptor.ts` matches a fixed set of Supabase hosts (incl. local `54361/54341`) plus a `localhost`/`127.0.0.1` + `/auth/v1/` | `/rest/v1/` fallback.
+- `manifest.json` injects content scripts and grants host permissions only for `app.trainingpeaks.com`, `planmypeak.com`, and `yqaskiwzyhhovthbvmqq.supabase.co`.
+- `VALIDATE_MY_PEAK_TOKEN` calls `GET {supabaseUrl}/auth/v1/user` with `Authorization: Bearer` + `apikey`, clearing the token on `401`.
+- URL resolution already goes through a configurable target layer (`portConfigService` / constants) with `local` vs `production` targets.
+
+The auth model itself is unchanged in kind — it is still a Supabase access token (JWT) plus the anon `apikey`, and Supabase GoTrue still exposes `/auth/v1/user`. What changed is _where_ that auth lives: a new portal host and (probably) a new Supabase project. Because the extension targets the old host and old project, it never captures tokens from the portal and, even if it did, would validate them against a project that did not mint them — so validation fails.
+
+This change is deliberately scoped to **auth capture + validation for the production target**. The data/export API surface (now `/api/backend`, with workout-library endpoints possibly absent) is a separate follow-up.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Capture the PlanMyPeak user access token and Supabase anon key from `https://portal.planmypeak.com` browser traffic.
+- Inject content scripts and hold host permissions for the portal origin and the production Supabase origin.
+- Validate the captured token against the Supabase project the portal actually authenticates against, and clear it on `401`.
+- Keep production URL resolution inside the existing configurable target layer (update defaults, do not scatter hardcoded literals).
+- Preserve the existing user-token-vs-anon-key discrimination so anon-key-only bearers are never stored as the user token.
+
+**Non-Goals:**
+
+- Updating the workout/library/training-plan API client (`/api/v1/...` → `/api/backend/...`) or reconciling missing library endpoints.
+- Local-dev port reconfiguration for the new monorepo (54321/54331, 3000/3001, 4000/4001, HTTPS). Out of scope for this production-focused change; tracked separately.
+- Changing the auth transport mechanism (still main-world intercept → isolated bridge → background storage → Supabase validation).
+- OAuth or any new login flow.
+
+## Decisions
+
+### Decision: Reuse the existing intercept → bridge → validate pipeline, only re-point hosts/URLs
+
+Rather than re-architect auth capture, keep the proven pipeline and change the host/URL inputs. The new portal still emits a Supabase Bearer token and anon `apikey`, so the existing `MY_PEAK_AUTH_FOUND` contract, storage keys, and `VALIDATE_MY_PEAK_TOKEN` handler remain valid.
+
+- _Alternative considered_: Switch to reading the Supabase session directly (e.g. from page storage). Rejected — higher coupling to the app's internals, more fragile across rewrites than header interception.
+
+### Decision: Production host is `portal.planmypeak.com`, resolved via the target config layer
+
+Update the `production` branch of the URL resolution (constants + `portConfigService`) so the app URL is `https://portal.planmypeak.com` and the Supabase URL is the confirmed production project. Update `mainWorldInterceptor.ts` host detection to recognize the portal origin and the production Supabase origin. Update `manifest.json` `content_scripts.matches` and `host_permissions` accordingly.
+
+- _Alternative considered_: Hardcode the new host at each call site. Rejected — violates the existing configurable-target design and the user's "configurable + new defaults" preference; would drift on the next rename.
+
+### Decision: Treat the production Supabase project URL as a confirm-then-set value
+
+The rewritten app uses a different Supabase project than the old `yqaskiwzyhhovthbvmqq.supabase.co`. The confirmed production project is **`https://nwvtltfibnkdogdeeluh.supabase.co`** — set this as the production Supabase default. The project-ref change is the confirmed root cause: portal-issued tokens validated against the old project always returned `401`. The anon-key value and `apikey`-header observability still need confirmation during implementation.
+
+- _Alternative considered_: Keep the old Supabase URL. Rejected — confirmed stale; validation fails silently with `401`.
+
+### Decision: Use the known public anon key for validation instead of relying on capture (added after manual testing)
+
+Manual testing of the production build showed PlanMyPeak still "not authenticated." Investigation of the portal confirmed: supabase-js restores the session from `localStorage` with **no network call**, and authenticated data goes to the portal's own `/api/backend` (same origin, `Authorization: Bearer` only — no `apikey` header). So the anon `apikey` is essentially never emitted on interceptable traffic, and validation — which required a captured `apikey` — always bailed.
+
+Resolution: embed the production Supabase anon (publishable) key as a constant and use it as the `apikey` when none was captured. The anon key is public and already baked into the portal's browser bundle, so embedding it exposes nothing new; it is static (expires 2036) and role-agnostic. Validation continues to hit Supabase `/auth/v1/user`, which authoritatively verifies the user token's signature/expiry regardless of coach/athlete role.
+
+- _Alternative considered_: Validate via a portal `/api/backend/*/me` endpoint with just the Bearer token. Rejected for now — the "me" endpoints are role-specific (coach vs athlete), so a single endpoint risks false-invalidating a valid token of the other role; the Supabase anon-key path is role-agnostic and authoritative.
+- _Token capture_ is unaffected: the user token is intercepted from `portal.planmypeak.com/api/backend/*` requests via the portal host match.
+
+### Decision: Keep `401` → clear-token behavior as the auth-state correctness mechanism
+
+The popup gate trusts stored auth; clearing on `401` is what flips a stale/foreign token to "not authenticated." Retain it and add/confirm test coverage for the new project URL.
+
+## Risks / Trade-offs
+
+- **Production Supabase project URL unknown / wrong** → Validation keeps returning `401`. Mitigation: explicit confirmation task before setting the default; verify a real portal-issued token returns `200`.
+- **Anon key differs or is no longer sent as a header on portal traffic** → user-token discrimination or the `apikey` validation header could break. Mitigation: inspect real portal network traffic for the `apikey` header presence and value during implementation; keep the `/auth/v1/user` exemption.
+- **Manifest changes require user re-grant of host permissions** → existing installs may need a permission re-prompt/reinstall. Mitigation: document in the release notes; verify on a clean profile.
+- **Portal may route API auth differently (e.g. proxied `/api/backend` on the portal origin rather than direct Supabase calls)** → token might be captured from portal API requests rather than Supabase requests. Mitigation: host detection covers the portal origin itself (Bearer on `portal.planmypeak.com/api/...`), not only the Supabase origin.
+- **Auth-only fix won't make export work end-to-end** → users may still hit failures in the export flow due to the deferred `/api/backend` endpoint changes. Mitigation: scope is communicated in the proposal; this change only claims to restore auth status, and the follow-up is noted.
+
+## Migration Plan
+
+1. Confirm the production Supabase project URL + anon-key header behavior for `portal.planmypeak.com`.
+2. Update production URL defaults (constants + `portConfigService`).
+3. Update `mainWorldInterceptor.ts` host detection for the portal + production Supabase origins.
+4. Update `manifest.json` matches + host permissions.
+5. Update/confirm `VALIDATE_MY_PEAK_TOKEN` resolves the production Supabase URL.
+6. Update unit tests (interceptor host detection; validation missing/invalid/valid/`401`).
+7. `npm run build`, load on a clean Chrome profile, log into the portal, confirm the popup shows PlanMyPeak authenticated and that an expired/foreign token is cleared.
+
+**Rollback**: Revert the constants/manifest/interceptor changes; the old configuration returns (still broken for the new portal, but no regression for unrelated TrainingPeaks/Intervals.icu flows since those paths are untouched).
+
+## Open Questions
+
+- ~~What is the production Supabase project URL used by `portal.planmypeak.com`?~~ **Resolved:** `https://nwvtltfibnkdogdeeluh.supabase.co` (changed from `yqaskiwzyhhovthbvmqq.supabase.co`). Anon key value still to confirm.
+- On the portal, is the user Supabase token observable on requests to the Supabase origin directly, on `portal.planmypeak.com/api/backend/*`, or both? (Determines which origins host detection must cover.)
+- Is the anon `apikey` still sent as a request header on portal traffic, or only embedded client-side? (Affects whether the validation `apikey` header can be sourced from interception.)
+- Should a separate production API host (if any, e.g. an `api.` subdomain) also be added to host permissions now, or deferred with the rest of the API work?

--- a/openspec/changes/fix-planmypeak-prod-auth-validation/proposal.md
+++ b/openspec/changes/fix-planmypeak-prod-auth-validation/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+PlanMyPeak has been rewritten and re-hosted. Production now lives at `https://portal.planmypeak.com/` (no longer the bare `planmypeak.com`), and the backend architecture changed (Supabase-authenticated Next.js web app proxying a separate Fastify API under `/api/backend`). The extension still captures and validates auth against the old host (`planmypeak.com`) and old Supabase project (`yqaskiwzyhhovthbvmqq.supabase.co`), so PlanMyPeak auth capture and the validate-token flow no longer work: tokens are never intercepted from the new portal traffic, and validation calls hit a Supabase project that did not issue the user's token.
+
+## What Changes
+
+- **BREAKING**: Update the PlanMyPeak **production** host from `planmypeak.com` to `portal.planmypeak.com` across the request interceptor, manifest match patterns, and host permissions.
+- Update the PlanMyPeak **production** Supabase project URL from the stale `https://yqaskiwzyhhovthbvmqq.supabase.co` to the project the rewritten app actually authenticates against: **`https://nwvtltfibnkdogdeeluh.supabase.co`** (confirmed). The project ref changed, which is the root cause: portal-issued tokens were being validated against a project that never issued them, so validation always returned `401` and the popup showed "Not Authenticated".
+- Update the main-world interceptor's host detection so it recognizes the new portal origin and the new production Supabase origin, and continues to distinguish the user access token from the Supabase anon `apikey` (still required: anon-key-only bearer tokens must not be stored as the user token).
+- Keep the validate-token flow's existing shape (`GET {supabaseUrl}/auth/v1/user` with `Authorization: Bearer <token>` + `apikey`) but point it at the confirmed production Supabase URL, and confirm it still returns `200` for a valid portal-issued token and clears stored auth on `401`.
+- Update production URL constants so the configurable target-switching layer resolves the correct portal app URL and Supabase URL, while preserving the existing in-extension configuration approach (no hardcoded one-off values).
+- Update `manifest.json` `content_scripts` matches and `host_permissions` so the interceptor injects on the portal and can reach the production Supabase auth endpoint.
+
+Out of scope (deferred): updating the workout/library/training-plan API client endpoints (e.g. `/api/v1/...` → `/api/backend/...`) and reconciling the missing workout-library resource. This change restores **auth capture and validation only**; export/data endpoints are a separate follow-up.
+
+## Capabilities
+
+### New Capabilities
+
+- `planmypeak-auth-validation`: Capturing a PlanMyPeak user access token (and Supabase anon key) from production portal browser traffic, storing it, and validating it against the correct Supabase project so the popup shows accurate PlanMyPeak authentication status.
+
+### Modified Capabilities
+
+<!-- No existing OpenSpec specs in openspec/specs/; nothing to modify. -->
+
+## Impact
+
+- **Code**:
+  - `src/content/mainWorldInterceptor.ts` — production host detection / URL matching.
+  - `src/content/isolatedWorldBridge.ts` — unchanged contract, verify forwarding still applies on the new origin.
+  - `src/utils/constants.ts` — production app URL and Supabase URL constants (and any supported-host/target config defaults).
+  - `src/background/messageHandler.ts` — `VALIDATE_MY_PEAK_TOKEN` target URL via the resolved Supabase URL; `401` clearing behavior.
+  - `src/services/portConfigService.ts` (and related target-resolution helpers) — production URL resolution.
+  - `public/manifest.json` — `content_scripts.matches` and `host_permissions` for `https://portal.planmypeak.com/*` and the production Supabase host.
+- **Auth/credentials**: Validation depends on the correct production Supabase project URL and anon key behavior.
+- **Confirmed**: Production Supabase project URL is `https://nwvtltfibnkdogdeeluh.supabase.co` (replaces the stale `yqaskiwzyhhovthbvmqq.supabase.co`). Still to confirm during implementation: the production anon key value and whether the `apikey` header is observable on portal traffic.
+- **Tests**: Background `VALIDATE_MY_PEAK_TOKEN` handler tests (missing/invalid/valid token, `401` clearing) and interceptor host-detection tests updated for the new origins.

--- a/openspec/changes/fix-planmypeak-prod-auth-validation/specs/planmypeak-auth-validation/spec.md
+++ b/openspec/changes/fix-planmypeak-prod-auth-validation/specs/planmypeak-auth-validation/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Capture PlanMyPeak auth from production portal traffic
+
+The extension SHALL intercept authenticated browser requests on the PlanMyPeak production portal origin (`https://portal.planmypeak.com`) and the production Supabase auth origin, and extract the user's Supabase access token (from the `Authorization: Bearer <token>` header) and the Supabase anon `apikey` header.
+
+The content script SHALL be injected on the production portal origin via the manifest `content_scripts` match patterns, and the extension SHALL hold host permissions for both the portal origin and the production Supabase origin.
+
+#### Scenario: Token captured from portal API request
+
+- **WHEN** a logged-in user's browser issues an authenticated request from `https://portal.planmypeak.com` carrying an `Authorization: Bearer <user-access-token>` header
+- **THEN** the main-world interceptor recognizes the origin, extracts the bearer token, and posts a `MY_PEAK_AUTH_FOUND` message containing the user token
+
+#### Scenario: Content script injects on the new portal origin
+
+- **WHEN** the user navigates to `https://portal.planmypeak.com`
+- **THEN** the manifest match patterns cause both the main-world interceptor and the isolated-world bridge to be injected at `document_start`
+
+#### Scenario: Old host no longer required
+
+- **WHEN** auth capture is configured for production
+- **THEN** the system targets `portal.planmypeak.com` rather than the former `planmypeak.com` host
+
+### Requirement: Distinguish user access token from Supabase anon key
+
+The extension SHALL NOT store the Supabase anon `apikey` as the user access token. A bearer token equal to the anon key SHALL be treated as a non-user token unless it originates from an `/auth/v1/user` request. The anon key SHALL be captured and stored separately for use in validation requests.
+
+#### Scenario: Anon-key-only bearer is not stored as user token
+
+- **WHEN** an intercepted request carries a bearer token identical to the Supabase anon `apikey` and is not an `/auth/v1/user` request
+- **THEN** the user token is reported as `null` while the anon key is still captured
+
+#### Scenario: User token from auth endpoint is stored
+
+- **WHEN** an intercepted `/auth/v1/user` request carries a bearer token
+- **THEN** that token is stored as the PlanMyPeak user access token together with the captured anon key
+
+### Requirement: Store partial auth independently
+
+The background worker SHALL persist the user access token, the Supabase anon key, and the capture timestamp independently, updating each only when a value is present, so credentials arriving in separate requests are not lost.
+
+#### Scenario: Anon key arrives before user token
+
+- **WHEN** the anon `apikey` is captured before the user access token
+- **THEN** the anon key is stored and the previously stored user token is not overwritten with `null`
+
+### Requirement: Validate token against the correct Supabase project
+
+The extension SHALL validate the stored PlanMyPeak token by calling `GET {supabaseUrl}/auth/v1/user` with `Authorization: Bearer <token>` and the `apikey` header, where `{supabaseUrl}` resolves to the Supabase project that the production portal authenticates against (not a stale project).
+
+#### Scenario: Valid token returns authenticated
+
+- **WHEN** the stored token was issued by the production portal's Supabase project and the validation request returns `200`
+- **THEN** the popup reports PlanMyPeak as authenticated
+
+#### Scenario: Validation targets the configured production Supabase URL
+
+- **WHEN** the production target is active
+- **THEN** the validation request is sent to the configured production Supabase project URL, not the former `yqaskiwzyhhovthbvmqq.supabase.co` value if that project no longer issues the portal's tokens
+
+### Requirement: Clear stored auth on rejected token
+
+The background worker SHALL clear the stored PlanMyPeak token when the validation request returns `401`, so the popup reflects a not-authenticated state instead of a stale valid state.
+
+#### Scenario: Expired or foreign token is cleared
+
+- **WHEN** the validation request to the Supabase project returns `401`
+- **THEN** the stored PlanMyPeak token is removed and the popup shows PlanMyPeak as not authenticated
+
+### Requirement: Resolve production URLs via configurable target
+
+The production PlanMyPeak app URL and Supabase URL SHALL be resolved through the existing target-switching configuration layer (not hardcoded at each call site), with production defaults set to the portal app URL and the confirmed production Supabase URL.
+
+#### Scenario: Production target resolves portal URLs
+
+- **WHEN** the extension resolves PlanMyPeak URLs for the production target
+- **THEN** the app URL resolves to `https://portal.planmypeak.com` and the Supabase URL resolves to the configured production Supabase project URL

--- a/openspec/changes/fix-planmypeak-prod-auth-validation/tasks.md
+++ b/openspec/changes/fix-planmypeak-prod-auth-validation/tasks.md
@@ -1,0 +1,58 @@
+## 1. Confirm production auth facts (do first — blocks correctness)
+
+- [x] 1.1 Determine the production Supabase project URL used by `https://portal.planmypeak.com`. **Confirmed: `https://nwvtltfibnkdogdeeluh.supabase.co`** (changed from `yqaskiwzyhhovthbvmqq.supabase.co` — this is the root cause).
+- [x] 1.2 Anon key is captured dynamically from the `apikey` request header (never hardcoded), so its literal value is not needed. Live confirmation that the header is present on portal traffic folds into manual verification (6.2).
+- [x] 1.3 Addressed defensively: host detection now captures from BOTH the Supabase project origin (`/auth/v1/*`, `/rest/v1/*`) and the `portal.planmypeak.com` app origin (Bearer on `/api/backend`), so the user token is captured regardless of which origin carries it. Any separate `api.` subdomain (if discovered during 6.2) can be added to `MYPEAK_APP_HOSTS` + host permissions.
+
+## 2. Update production URL configuration
+
+- [x] 2.1 `src/utils/constants.ts`: `PLANMYPEAK_APP_URL` and `PLANMYPEAK_HOST_LABEL` production values now `portal.planmypeak.com`.
+- [x] 2.2 `src/utils/constants.ts`: `PLANMYPEAK_AUTH_BASE_URL` production value now `https://nwvtltfibnkdogdeeluh.supabase.co`. `manifest.json` host permission updated to the new project (task 3.4).
+- [x] 2.3 `src/services/portConfigService.ts` now imports and returns the production constants (`PLANMYPEAK_APP_URL` / `PLANMYPEAK_AUTH_BASE_URL` / `PLANMYPEAK_HOST_LABEL`) instead of re-hardcoding literals, so production URLs are defined once in constants.
+
+## 3. Update auth capture (interceptor + bridge + manifest)
+
+- [x] 3.1 Host detection extracted to the pure module `src/content/mypeakAuthDetection.ts` (imported by `mainWorldInterceptor.ts`); now matches the new Supabase project host and `portal.planmypeak.com`.
+- [x] 3.2 Discrimination logic unchanged: anon-key-only bearer is still not stored as the user token, the `/auth/v1/user` exemption is preserved, and a JWT bearer on the portal origin is correctly treated as the user token (no apikey on those calls → user token still posted via partial storage).
+- [x] 3.3 `public/manifest.json`: `content_scripts.matches` (MAIN + ISOLATED) and `host_permissions` now use `https://portal.planmypeak.com/*`.
+- [x] 3.4 `public/manifest.json`: host permission updated to `https://nwvtltfibnkdogdeeluh.supabase.co/*`. No separate `api.` subdomain known yet (revisit during 6.2 if found).
+- [x] 3.5 `isolatedWorldBridge.ts` forwards `MY_PEAK_AUTH_FOUND` purely on message type/source, independent of origin — no change needed.
+
+## 4. Update token validation
+
+- [x] 4.1 Confirmed: `handleValidateMyPeakToken` resolves `getSupabaseUrl()` (now the production project in production builds) and calls `GET {supabaseUrl}/auth/v1/user` with `Authorization: Bearer` + `apikey`. No code change needed; covered by new tests.
+- [x] 4.2 Confirmed: the `401` branch clears `mypeak_auth_token` + `mypeak_token_timestamp`. Covered by a new test.
+
+## 5. Tests
+
+- [x] 5.1 Added `tests/unit/content/mypeakAuthDetection.test.ts`: matches new Supabase host + portal origin + local ports; rejects retired host and bare `planmypeak.com`.
+- [x] 5.2 Added `VALIDATE_MY_PEAK_TOKEN` tests to `tests/unit/background/messageHandler.test.ts`: no token, missing anon key, valid `200` (asserts `/auth/v1/user` + Bearer + apikey), `401` clears storage. Also updated the env-indicator test for the new host.
+- [x] 5.3 Ran the affected suites — all 25 PlanMyPeak auth/detection/env tests pass; `tsc --noEmit` clean. (Pre-existing, unrelated calendar + Playwright-e2e failures exist on the baseline and are untouched by this change.)
+
+## 5b. Validation no longer depends on a captured anon key (root-cause follow-up)
+
+Discovered during manual testing (popup showed "not authenticated" on 1.11.84): the rewritten portal restores its Supabase session from `localStorage` (no network call) and routes data through its own `/api/backend`, so the anon `apikey` header is essentially never emitted on intercepted traffic. The user token IS captured (from `portal.planmypeak.com/api/backend/*`), but `handleValidateMyPeakToken` bailed at `if (!apiKey)`.
+
+- [x] 5b.1 Added `PLANMYPEAK_SUPABASE_ANON_KEY` constant (`src/utils/constants.ts`) — the public, static production publishable key baked into the portal browser build (project ref `nwvtltfibnkdogdeeluh`, confirmed from the PlanMyPeak repo `infra/live/prod/env.hcl`). Empty for local builds.
+- [x] 5b.2 `handleValidateMyPeakToken` now uses `capturedApiKey || PLANMYPEAK_SUPABASE_ANON_KEY` so production validation works without capturing the anon key; local still relies on the captured key.
+- [x] 5b.3 Confirmed via build that the anon key + Supabase host are baked into `dist/`. (Compile-time target flag makes the production fallback path not unit-testable in the DEV test env; covered by existing handler tests + build verification + manual 6.2.)
+
+## 5c. Why is capture failing on `portal.planmypeak.com`? (root-cause follow-up #2 — OPEN)
+
+Second manual test (1.11.85) showed `chrome.storage.local` empty for all `mypeak_*` keys → the token was never captured — even though `portal.planmypeak.com` was already in the match list. So the host list is NOT the problem.
+
+A brief detour added `api.planmypeak.com` (from the repo's `infra/live/prod/env.hcl`), but the user confirmed their deployment serves everything from `portal.planmypeak.com` (no separate API host). That change was **reverted**.
+
+Diagnosed on the live portal (via a temporary always-on diagnostic build, since production logging is off):
+
+- [x] 5c.1 Interceptor IS injecting on `portal.planmypeak.com` (`window.fetch` shows our wrapper).
+- [x] 5c.2 Auth travels as an `Authorization: Bearer` header on the portal's API requests. The diagnostic showed the app calls them with **relative URLs** (`/api/backend/coaches/me`, `/api/backend/activities`, …, `inputType: string`) — same origin, no separate API host.
+- [x] 5c.3 **Root cause:** host-based detection did `url.includes('portal.planmypeak.com')`, but a relative URL has no host → `match: false`, so the token (which we could read — `auth: YES`) was discarded. Fixed by resolving relative request URLs to absolute against the page origin (`document.baseURI`) before detection, via `toAbsoluteUrl()` in `src/content/requestInfo.ts`. After the fix the diagnostic showed `match: true` + `POSTED MY_PEAK_AUTH_FOUND | token: true` for `/api/backend/*`.
+- [x] 5c.4 Also hardened the fetch wrapper to read headers from a `Request` object (not only `options.headers`) via `extractRequestInfo()`. Covered by `tests/unit/content/requestInfo.test.ts` (Request-object, url+init, URL object, override, and relative→absolute resolution).
+- [x] 5c.5 Removed the temporary `[PMP-DIAG]` diagnostic logging; shipped clean build.
+
+## 6. Build & manual verification
+
+- [x] 6.1 `npm run build` succeeds; built `dist/manifest.json` and `dist/assets/*.js` carry the new hosts + anon key and zero references to the retired project. **Manual:** loading the unpacked build on a clean Chrome profile (re-grant host permissions) remains for you.
+- [x] 6.2 **Confirmed by user:** logged in at `https://portal.planmypeak.com`, popup shows PlanMyPeak **Authenticated**. Token captured from relative `/api/backend/*` requests; validated via the embedded anon key. (No `apikey` on portal traffic and no separate `api.` host — both handled.)
+- [ ] 6.3 **Manual (optional):** Confirm an expired/foreign token yields a `401` and the popup flips to not-authenticated (token cleared). Logic unchanged + unit-tested; not separately exercised in the browser.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "planmypeak-importer",
-  "version": "1.11.83",
+  "version": "1.11.90",
   "description": "PlanMyPeak Importer - Browser Extension for Workout Library Access",
   "type": "module",
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,16 +1,16 @@
 {
   "manifest_version": 3,
   "name": "PlanMyPeak Importer",
-  "version": "1.11.83",
+  "version": "1.11.90",
   "description": "Access your workout libraries and training plans directly from your browser",
   "permissions": ["storage", "tabs", "notifications"],
   "host_permissions": [
     "https://tpapi.trainingpeaks.com/*",
     "https://api.peakswaresb.com/*",
     "https://app.trainingpeaks.com/*",
-    "https://planmypeak.com/*",
+    "https://portal.planmypeak.com/*",
     "https://intervals.icu/*",
-    "https://yqaskiwzyhhovthbvmqq.supabase.co/*"
+    "https://nwvtltfibnkdogdeeluh.supabase.co/*"
   ],
   "background": {
     "service_worker": "src/background/index.ts",
@@ -28,7 +28,7 @@
     {
       "matches": [
         "https://app.trainingpeaks.com/*",
-        "https://planmypeak.com/*"
+        "https://portal.planmypeak.com/*"
       ],
       "js": ["src/content/mainWorldInterceptor.ts"],
       "run_at": "document_start",
@@ -37,7 +37,7 @@
     {
       "matches": [
         "https://app.trainingpeaks.com/*",
-        "https://planmypeak.com/*"
+        "https://portal.planmypeak.com/*"
       ],
       "js": ["src/content/isolatedWorldBridge.ts"],
       "run_at": "document_start",

--- a/src/background/messageHandler.ts
+++ b/src/background/messageHandler.ts
@@ -37,6 +37,7 @@ import {
   API_BASE_URL,
   STORAGE_KEYS,
   createApiHeaders,
+  PLANMYPEAK_SUPABASE_ANON_KEY,
 } from '@/utils/constants';
 import { getSupabaseUrl } from '@/services/portConfigService';
 import {
@@ -308,9 +309,16 @@ async function handleValidateMyPeakToken(): Promise<{
     ]);
 
     const token = data[STORAGE_KEYS.MYPEAK_AUTH_TOKEN] as string | undefined;
-    const apiKey = data[STORAGE_KEYS.MYPEAK_SUPABASE_API_KEY] as
+    const capturedApiKey = data[STORAGE_KEYS.MYPEAK_SUPABASE_API_KEY] as
       | string
       | undefined;
+
+    // The rewritten portal restores its session from localStorage and routes
+    // data through its own /api/backend, so the anon `apikey` header is rarely
+    // emitted on intercepted traffic. Fall back to the known public anon key so
+    // validation does not depend on capturing it. (Empty for local builds,
+    // which still rely on the captured key.)
+    const apiKey = capturedApiKey || PLANMYPEAK_SUPABASE_ANON_KEY;
 
     if (!token) {
       logger.debug('No MyPeak auth token to validate');
@@ -318,7 +326,7 @@ async function handleValidateMyPeakToken(): Promise<{
     }
 
     if (!apiKey) {
-      logger.debug('No MyPeak Supabase API key captured yet');
+      logger.debug('No MyPeak Supabase API key available');
       return { valid: false };
     }
 

--- a/src/content/mainWorldInterceptor.ts
+++ b/src/content/mainWorldInterceptor.ts
@@ -5,41 +5,13 @@
  * It intercepts fetch/XHR and uses postMessage to send tokens to the isolated world.
  */
 
+import { isMyPeakSupabaseRequest } from './mypeakAuthDetection';
+import { extractRequestInfo, toAbsoluteUrl } from './requestInfo';
+
 const DEBUG = import.meta.env.DEV;
 const log = (...args: unknown[]): void => {
   if (DEBUG) console.log('[TP Extension - MAIN World]', ...args);
 };
-
-/**
- * Known Supabase hosts for PlanMyPeak auth detection.
- * Includes cloud Supabase and common local development ports.
- */
-const MYPEAK_SUPABASE_HOSTS = [
-  '127.0.0.1:54361',
-  'localhost:54361',
-  '127.0.0.1:54341',
-  'localhost:54341',
-  'yqaskiwzyhhovthbvmqq.supabase.co',
-];
-
-/**
- * Check if URL matches a Supabase auth request pattern.
- * Detects both known hosts and any localhost Supabase auth endpoint.
- */
-function isMyPeakSupabaseRequest(url: string): boolean {
-  // Check known hosts first
-  if (MYPEAK_SUPABASE_HOSTS.some((host) => url.includes(host))) {
-    return true;
-  }
-
-  // Also detect any localhost/127.0.0.1 Supabase auth endpoints
-  // This allows flexible port configuration in local development
-  const isLocalhost = url.includes('localhost:') || url.includes('127.0.0.1:');
-  const isSupabaseAuthPath =
-    url.includes('/auth/v1/') || url.includes('/rest/v1/');
-
-  return isLocalhost && isSupabaseAuthPath;
-}
 
 function maybePostMyPeakSupabaseAuth(
   url: string,
@@ -96,56 +68,52 @@ let fetchCount = 0;
 // Intercept fetch
 window.fetch = async function (...args) {
   fetchCount++;
-  const [url, options] = args;
-  const urlStr = typeof url === 'string' ? url : url.toString();
+  const { urlStr: rawUrl, headers } = extractRequestInfo(args[0], args[1]);
+  // Resolve relative URLs (e.g. fetch('/api/backend/...')) against the page
+  // origin so host-based detection can match them.
+  const urlStr = toAbsoluteUrl(rawUrl, document.baseURI);
 
   log('📡 Fetch request #' + fetchCount + ':', urlStr);
 
-  // Check for Authorization header
-  if (options && options.headers) {
-    const headers = new Headers(options.headers);
-    const authHeader = headers.get('authorization');
+  const authHeader = headers.get('authorization');
 
-    log('  ✓ Has headers, Authorization:', authHeader ? 'present' : 'none');
+  log('  ✓ Authorization:', authHeader ? 'present' : 'none');
 
-    if (authHeader && authHeader.startsWith('Bearer ')) {
-      const token = authHeader.substring(7);
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.substring(7);
 
-      // Only capture TrainingPeaks encrypted tokens (start with "gAAAA")
-      // NOT JWT tokens (start with "eyJ")
-      const isEncryptedToken = token.startsWith('gAAAA');
-      const isApiCall = urlStr.includes('tpapi.trainingpeaks.com');
+    // Only capture TrainingPeaks encrypted tokens (start with "gAAAA")
+    // NOT JWT tokens (start with "eyJ")
+    const isEncryptedToken = token.startsWith('gAAAA');
+    const isApiCall = urlStr.includes('tpapi.trainingpeaks.com');
 
-      log('  🎫 Bearer token detected', {
-        length: token.length,
-        tokenType: isEncryptedToken ? 'encrypted' : 'jwt',
-        isApiCall,
-      });
+    log('  🎫 Bearer token detected', {
+      length: token.length,
+      tokenType: isEncryptedToken ? 'encrypted' : 'jwt',
+      isApiCall,
+    });
 
-      if (isEncryptedToken && isApiCall) {
-        log('  ✅ Valid TrainingPeaks API token! Posting to isolated world...');
+    if (isEncryptedToken && isApiCall) {
+      log('  ✅ Valid TrainingPeaks API token! Posting to isolated world...');
 
-        // Send token to isolated world content script via postMessage
-        window.postMessage(
-          {
-            type: 'TP_TOKEN_FOUND',
-            token: token,
-            timestamp: Date.now(),
-            source: 'trainingpeaks-extension-main',
-          },
-          '*'
-        );
+      // Send token to isolated world content script via postMessage
+      window.postMessage(
+        {
+          type: 'TP_TOKEN_FOUND',
+          token: token,
+          timestamp: Date.now(),
+          source: 'trainingpeaks-extension-main',
+        },
+        '*'
+      );
 
-        log('  ✅ Token posted');
-      } else {
-        log('  ⏭️ Skipping non-TrainingPeaks token candidate');
-      }
+      log('  ✅ Token posted');
+    } else {
+      log('  ⏭️ Skipping non-TrainingPeaks token candidate');
     }
-
-    maybePostMyPeakSupabaseAuth(urlStr, headers, 'fetch');
-  } else {
-    log('  ℹ️  No headers');
   }
+
+  maybePostMyPeakSupabaseAuth(urlStr, headers, 'fetch');
 
   return originalFetch.apply(this, args);
 };
@@ -180,13 +148,14 @@ XMLHttpRequest.prototype.open = function (
   password?: string | null
 ) {
   xhrCount++;
-  log('📡 XHR request #' + xhrCount + ':', method, url.toString());
+  const xhrUrlAbs = toAbsoluteUrl(url.toString(), document.baseURI);
+  log('📡 XHR request #' + xhrCount + ':', method, xhrUrlAbs);
 
   this.addEventListener('loadstart', function () {
     const headers = xhrHeaders.get(this);
     if (headers) {
       maybePostMyPeakSupabaseAuth(
-        url.toString(),
+        xhrUrlAbs,
         new Headers(Array.from(headers.entries())),
         'xhr'
       );

--- a/src/content/mypeakAuthDetection.ts
+++ b/src/content/mypeakAuthDetection.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure detection helpers for PlanMyPeak auth-bearing requests.
+ *
+ * Extracted from the main-world interceptor so the URL matching logic can be
+ * unit tested without triggering the interceptor's fetch/XHR patching side
+ * effects.
+ */
+
+/**
+ * Known Supabase hosts for PlanMyPeak auth detection.
+ * Includes the production cloud Supabase project and common local development ports.
+ */
+export const MYPEAK_SUPABASE_HOSTS = [
+  '127.0.0.1:54361',
+  'localhost:54361',
+  '127.0.0.1:54341',
+  'localhost:54341',
+  'nwvtltfibnkdogdeeluh.supabase.co',
+];
+
+/**
+ * PlanMyPeak origins that carry the user's Supabase access token as a Bearer
+ * header on API requests (e.g. `portal.planmypeak.com/api/backend/*`).
+ * Capturing here ensures the user token is detected even though app data calls
+ * do not go through Supabase directly.
+ */
+export const MYPEAK_APP_HOSTS = ['portal.planmypeak.com'];
+
+/**
+ * Check if a URL is a PlanMyPeak auth-bearing request.
+ * Matches the Supabase project hosts, the PlanMyPeak portal app origin, and any
+ * localhost Supabase auth endpoint (for local development).
+ */
+export function isMyPeakSupabaseRequest(url: string): boolean {
+  // Check known Supabase project hosts first
+  if (MYPEAK_SUPABASE_HOSTS.some((host) => url.includes(host))) {
+    return true;
+  }
+
+  // PlanMyPeak portal API requests carry the user access token as a Bearer header
+  if (MYPEAK_APP_HOSTS.some((host) => url.includes(host))) {
+    return true;
+  }
+
+  // Also detect any localhost/127.0.0.1 Supabase auth endpoints
+  // This allows flexible port configuration in local development
+  const isLocalhost = url.includes('localhost:') || url.includes('127.0.0.1:');
+  const isSupabaseAuthPath =
+    url.includes('/auth/v1/') || url.includes('/rest/v1/');
+
+  return isLocalhost && isSupabaseAuthPath;
+}

--- a/src/content/requestInfo.ts
+++ b/src/content/requestInfo.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure helper to extract the URL and headers from fetch() arguments,
+ * regardless of how the caller passed them.
+ *
+ * Extracted from the main-world interceptor so it can be unit tested without
+ * triggering the interceptor's fetch/XHR patching side effects.
+ *
+ * Handles every fetch call shape:
+ *  - fetch(urlString, init)
+ *  - fetch(URL, init)
+ *  - fetch(Request)            ← headers live on the Request, not on init
+ *  - fetch(Request, init)      ← init.headers override/augment the Request's
+ *
+ * The Request-object form is the important one: apps (and fetch wrappers)
+ * frequently build a Request, so the `Authorization` header is on the Request
+ * itself. Reading only `init.headers` would miss it entirely.
+ */
+export function extractRequestInfo(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): { urlStr: string; headers: Headers } {
+  let urlStr = '';
+  let headers = new Headers();
+
+  if (typeof Request !== 'undefined' && input instanceof Request) {
+    urlStr = input.url;
+    headers = new Headers(input.headers);
+  } else {
+    urlStr = typeof input === 'string' ? input : input.toString();
+  }
+
+  // init.headers (when provided) augments/overrides the Request's headers.
+  if (init && init.headers) {
+    const initHeaders = new Headers(init.headers);
+    initHeaders.forEach((value, key) => headers.set(key, value));
+  }
+
+  return { urlStr, headers };
+}
+
+/**
+ * Resolve a possibly-relative request URL to an absolute URL against `base`.
+ *
+ * Apps call `fetch('/api/backend/...')` with a relative URL, which has no host —
+ * so host-based detection would miss it. Resolving against the page origin
+ * (`document.baseURI`) yields e.g. `https://portal.planmypeak.com/api/backend/...`
+ * so host matching works. Returns the input unchanged if it cannot be parsed.
+ */
+export function toAbsoluteUrl(url: string, base: string): string {
+  try {
+    return new URL(url, base).href;
+  } catch {
+    return url;
+  }
+}

--- a/src/popup/components/PlanMyPeakEnvironmentIndicator.tsx
+++ b/src/popup/components/PlanMyPeakEnvironmentIndicator.tsx
@@ -25,7 +25,7 @@ export function PlanMyPeakEnvironmentIndicator({
             Local PlanMyPeak Target
           </p>
           <p className="text-xs text-amber-800">
-            This build targets {hostLabel} instead of planmypeak.com.
+            This build targets {hostLabel} instead of portal.planmypeak.com.
           </p>
         </div>
       </div>

--- a/src/services/portConfigService.ts
+++ b/src/services/portConfigService.ts
@@ -12,6 +12,9 @@ import {
   IS_LOCAL_PLANMYPEAK_TARGET,
   isSupportedPlanMyPeakAppPort,
   isSupportedPlanMyPeakSupabasePort,
+  PLANMYPEAK_APP_URL,
+  PLANMYPEAK_AUTH_BASE_URL,
+  PLANMYPEAK_HOST_LABEL,
 } from '@/utils/constants';
 
 export interface PortConfig {
@@ -138,7 +141,7 @@ export async function resetPortConfig(): Promise<void> {
  */
 export async function getPlanMyPeakAppUrl(): Promise<string> {
   if (!IS_LOCAL_PLANMYPEAK_TARGET) {
-    return 'https://planmypeak.com';
+    return PLANMYPEAK_APP_URL;
   }
 
   const port = await getAppPort();
@@ -160,7 +163,7 @@ export async function getPlanMyPeakApiUrl(): Promise<string> {
  */
 export async function getSupabaseUrl(): Promise<string> {
   if (!IS_LOCAL_PLANMYPEAK_TARGET) {
-    return 'https://yqaskiwzyhhovthbvmqq.supabase.co';
+    return PLANMYPEAK_AUTH_BASE_URL;
   }
 
   const port = await getSupabasePort();
@@ -172,7 +175,7 @@ export async function getSupabaseUrl(): Promise<string> {
  */
 export async function getHostLabel(): Promise<string> {
   if (!IS_LOCAL_PLANMYPEAK_TARGET) {
-    return 'planmypeak.com';
+    return PLANMYPEAK_HOST_LABEL;
   }
 
   const port = await getAppPort();

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -78,23 +78,38 @@ export function isSupportedPlanMyPeakSupabasePort(port: number): boolean {
  */
 export const PLANMYPEAK_APP_URL = IS_LOCAL_PLANMYPEAK_TARGET
   ? `http://localhost:${DEFAULT_PLANMYPEAK_APP_PORT}`
-  : 'https://planmypeak.com';
+  : 'https://portal.planmypeak.com';
 
 /**
  * Short PlanMyPeak host label for UI copy (uses default port).
  */
 export const PLANMYPEAK_HOST_LABEL = IS_LOCAL_PLANMYPEAK_TARGET
   ? `localhost:${DEFAULT_PLANMYPEAK_APP_PORT}`
-  : 'planmypeak.com';
+  : 'portal.planmypeak.com';
 
 /**
  * PlanMyPeak auth validation base URL (uses default port, actual port may be configured in local builds).
  * Development hits the local Supabase instance directly.
- * Production validates via the Supabase cloud instance.
+ * Production validates via the Supabase cloud instance the rewritten portal authenticates against.
  */
 export const PLANMYPEAK_AUTH_BASE_URL = IS_LOCAL_PLANMYPEAK_TARGET
   ? `http://127.0.0.1:${DEFAULT_PLANMYPEAK_SUPABASE_PORT}`
-  : 'https://yqaskiwzyhhovthbvmqq.supabase.co';
+  : 'https://nwvtltfibnkdogdeeluh.supabase.co';
+
+/**
+ * PlanMyPeak Supabase anon (publishable) key, used as the `apikey` header when
+ * validating a captured user token against Supabase `/auth/v1/user`.
+ *
+ * The rewritten portal restores its session from localStorage and routes data
+ * through its own `/api/backend`, so the anon key is (almost) never emitted on
+ * intercepted traffic. This is the public, static publishable key baked into
+ * the production portal browser build, so embedding it here is equivalent to
+ * what the web app already ships. Local builds fall back to the anon key
+ * captured from intercepted local Supabase traffic.
+ */
+export const PLANMYPEAK_SUPABASE_ANON_KEY = IS_LOCAL_PLANMYPEAK_TARGET
+  ? ''
+  : 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im53dnRsdGZpYm5rZG9nZGVlbHVoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODIxMTE3ODgsImV4cCI6MjA5NzY4Nzc4OH0.WqJxwP_OTwbFjo_n1yJWENpy3Xq5xOVzqQ9YcACRr54';
 
 /**
  * PlanMyPeak API base URL.

--- a/tests/unit/background/messageHandler.test.ts
+++ b/tests/unit/background/messageHandler.test.ts
@@ -412,4 +412,106 @@ describe('messageHandler', () => {
       ]);
     });
   });
+
+  describe('VALIDATE_MY_PEAK_TOKEN message', () => {
+    it('should return invalid without calling fetch when no token is stored', async () => {
+      global.chrome = {
+        storage: {
+          local: {
+            get: vi.fn().mockResolvedValue({}),
+          },
+        },
+      } as any;
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as any;
+
+      const result = await handleMessage(
+        { type: 'VALIDATE_MY_PEAK_TOKEN' as const },
+        mockSender
+      );
+
+      expect(result).toEqual({ valid: false });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should return invalid without calling fetch when the Supabase anon key is missing', async () => {
+      global.chrome = {
+        storage: {
+          local: {
+            get: vi.fn().mockResolvedValue({ mypeak_auth_token: 'user-token' }),
+          },
+        },
+      } as any;
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as any;
+
+      const result = await handleMessage(
+        { type: 'VALIDATE_MY_PEAK_TOKEN' as const },
+        mockSender
+      );
+
+      expect(result).toEqual({ valid: false });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should validate against the Supabase /auth/v1/user endpoint with Bearer + apikey', async () => {
+      global.chrome = {
+        storage: {
+          local: {
+            get: vi.fn().mockResolvedValue({
+              mypeak_auth_token: 'user-token',
+              mypeak_supabase_api_key: 'anon-key',
+            }),
+          },
+        },
+      } as any;
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 'athlete-123' }),
+      });
+      global.fetch = fetchMock as any;
+
+      const result = await handleMessage(
+        { type: 'VALIDATE_MY_PEAK_TOKEN' as const },
+        mockSender
+      );
+
+      expect(result).toEqual({ valid: true, userId: 'athlete-123' });
+      const [endpoint, init] = fetchMock.mock.calls[0];
+      expect(endpoint).toMatch(/\/auth\/v1\/user$/);
+      expect(init.headers.authorization).toBe('Bearer user-token');
+      expect(init.headers.apikey).toBe('anon-key');
+    });
+
+    it('should clear the stored MyPeak token on a 401 response', async () => {
+      const mockRemove = vi.fn().mockResolvedValue(undefined);
+      global.chrome = {
+        storage: {
+          local: {
+            get: vi.fn().mockResolvedValue({
+              mypeak_auth_token: 'expired-token',
+              mypeak_supabase_api_key: 'anon-key',
+            }),
+            remove: mockRemove,
+          },
+        },
+      } as any;
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => 'Unauthorized',
+      }) as any;
+
+      const result = await handleMessage(
+        { type: 'VALIDATE_MY_PEAK_TOKEN' as const },
+        mockSender
+      );
+
+      expect(result).toEqual({ valid: false });
+      expect(mockRemove).toHaveBeenCalledWith([
+        'mypeak_auth_token',
+        'mypeak_token_timestamp',
+      ]);
+    });
+  });
 });

--- a/tests/unit/components/PlanMyPeakEnvironmentIndicator.test.tsx
+++ b/tests/unit/components/PlanMyPeakEnvironmentIndicator.test.tsx
@@ -14,7 +14,7 @@ describe('PlanMyPeakEnvironmentIndicator', () => {
     expect(screen.getByText('Local PlanMyPeak Target')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'This build targets localhost:3006 instead of planmypeak.com.'
+        'This build targets localhost:3006 instead of portal.planmypeak.com.'
       )
     ).toBeInTheDocument();
   });
@@ -23,7 +23,7 @@ describe('PlanMyPeakEnvironmentIndicator', () => {
     const { container } = render(
       <PlanMyPeakEnvironmentIndicator
         isVisible={false}
-        hostLabel="planmypeak.com"
+        hostLabel="portal.planmypeak.com"
       />
     );
 

--- a/tests/unit/content/mypeakAuthDetection.test.ts
+++ b/tests/unit/content/mypeakAuthDetection.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isMyPeakSupabaseRequest,
+  MYPEAK_SUPABASE_HOSTS,
+  MYPEAK_APP_HOSTS,
+} from '@/content/mypeakAuthDetection';
+
+describe('mypeakAuthDetection', () => {
+  describe('isMyPeakSupabaseRequest', () => {
+    it('should match the production Supabase project host', () => {
+      expect(
+        isMyPeakSupabaseRequest(
+          'https://nwvtltfibnkdogdeeluh.supabase.co/auth/v1/user'
+        )
+      ).toBe(true);
+    });
+
+    it('should match the production portal app origin (api/backend traffic)', () => {
+      expect(
+        isMyPeakSupabaseRequest(
+          'https://portal.planmypeak.com/api/backend/athletes'
+        )
+      ).toBe(true);
+    });
+
+    it('should match local Supabase auth endpoints on any localhost port', () => {
+      expect(
+        isMyPeakSupabaseRequest('http://127.0.0.1:54331/auth/v1/user')
+      ).toBe(true);
+      expect(
+        isMyPeakSupabaseRequest('http://localhost:54361/rest/v1/workouts')
+      ).toBe(true);
+    });
+
+    it('should NOT match the retired Supabase project host', () => {
+      expect(
+        isMyPeakSupabaseRequest(
+          'https://yqaskiwzyhhovthbvmqq.supabase.co/auth/v1/user'
+        )
+      ).toBe(false);
+    });
+
+    it('should NOT match the retired bare planmypeak.com host', () => {
+      expect(
+        isMyPeakSupabaseRequest('https://planmypeak.com/api/backend/athletes')
+      ).toBe(false);
+    });
+
+    it('should NOT match unrelated hosts', () => {
+      expect(
+        isMyPeakSupabaseRequest('https://tpapi.trainingpeaks.com/users/v3/user')
+      ).toBe(false);
+      expect(
+        isMyPeakSupabaseRequest('https://intervals.icu/api/v1/athlete')
+      ).toBe(false);
+    });
+  });
+
+  describe('host constants', () => {
+    it('should target the new Supabase project, not the retired one', () => {
+      expect(MYPEAK_SUPABASE_HOSTS).toContain(
+        'nwvtltfibnkdogdeeluh.supabase.co'
+      );
+      expect(MYPEAK_SUPABASE_HOSTS).not.toContain(
+        'yqaskiwzyhhovthbvmqq.supabase.co'
+      );
+    });
+
+    it('should target the portal app origin', () => {
+      expect(MYPEAK_APP_HOSTS).toContain('portal.planmypeak.com');
+    });
+  });
+});

--- a/tests/unit/content/requestInfo.test.ts
+++ b/tests/unit/content/requestInfo.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { extractRequestInfo, toAbsoluteUrl } from '@/content/requestInfo';
+
+describe('extractRequestInfo', () => {
+  it('reads url + headers from fetch(urlString, init)', () => {
+    const { urlStr, headers } = extractRequestInfo(
+      'https://portal.planmypeak.com/api/backend/athlete/me',
+      { headers: { authorization: 'Bearer token-1' } }
+    );
+
+    expect(urlStr).toBe('https://portal.planmypeak.com/api/backend/athlete/me');
+    expect(headers.get('authorization')).toBe('Bearer token-1');
+  });
+
+  it('reads the Authorization header from a Request object (no init)', () => {
+    const request = new Request(
+      'https://portal.planmypeak.com/api/backend/athlete/me/activities/abc/review',
+      { headers: { authorization: 'Bearer token-2', apikey: 'anon' } }
+    );
+
+    const { urlStr, headers } = extractRequestInfo(request);
+
+    expect(urlStr).toContain('/api/backend/athlete/me/activities/abc/review');
+    expect(headers.get('authorization')).toBe('Bearer token-2');
+    expect(headers.get('apikey')).toBe('anon');
+  });
+
+  it('lets init.headers override a Request object headers', () => {
+    const request = new Request('https://portal.planmypeak.com/api/backend/x', {
+      headers: { authorization: 'Bearer old' },
+    });
+
+    const { headers } = extractRequestInfo(request, {
+      headers: { authorization: 'Bearer new' },
+    });
+
+    expect(headers.get('authorization')).toBe('Bearer new');
+  });
+
+  it('handles a URL object input', () => {
+    const { urlStr } = extractRequestInfo(
+      new URL('https://portal.planmypeak.com/api/backend/x')
+    );
+
+    expect(urlStr).toBe('https://portal.planmypeak.com/api/backend/x');
+  });
+
+  it('returns empty headers when none are provided', () => {
+    const { headers } = extractRequestInfo('https://example.com');
+    expect(headers.get('authorization')).toBeNull();
+  });
+});
+
+describe('toAbsoluteUrl', () => {
+  it('resolves a relative /api/backend path against the portal origin', () => {
+    expect(
+      toAbsoluteUrl(
+        '/api/backend/coaches/me',
+        'https://portal.planmypeak.com/dashboard'
+      )
+    ).toBe('https://portal.planmypeak.com/api/backend/coaches/me');
+  });
+
+  it('leaves an already-absolute URL unchanged', () => {
+    expect(
+      toAbsoluteUrl(
+        'https://portal.planmypeak.com/api/backend/events',
+        'https://portal.planmypeak.com/dashboard'
+      )
+    ).toBe('https://portal.planmypeak.com/api/backend/events');
+  });
+
+  it('returns the input unchanged when it cannot be parsed', () => {
+    expect(toAbsoluteUrl('/api/backend/x', '')).toBe('/api/backend/x');
+  });
+});


### PR DESCRIPTION
## Summary

PlanMyPeak was rewritten and re-hosted, which broke the extension's PlanMyPeak auth capture and validation (popup showed **Not Authenticated**). This restores it. Three independent bugs were uncovered and fixed — **verified live: the popup now shows PlanMyPeak authenticated**.

### 1. Wrong Supabase project / host
Production moved to `portal.planmypeak.com` with a **new Supabase project** (`nwvtltfibnkdogdeeluh`, was `yqaskiwzyhhovthbvmqq`). Tokens were validated against a project that never issued them → always `401`. Updated production URLs in `constants.ts`, host detection, and `manifest.json` (matches + host permissions).

### 2. Validation required an anon key the portal never emits
The rewritten portal restores its Supabase session from `localStorage` (no network call) and sends data to its own API with **no `apikey` header** — so the anon key is never interceptable. Embedded the **public** production anon key (`PLANMYPEAK_SUPABASE_ANON_KEY`, the same publishable key baked into the portal's browser build) and fall back to it when validating via Supabase `/auth/v1/user` (authoritative + role-agnostic).

### 3. Token was never captured
The portal calls its API with **relative URLs** (`/api/backend/coaches/me`), which have no host, so host-based detection never matched and the token was discarded. Now resolve relative request URLs to absolute against the page origin before detection, and read headers off `Request` objects (not only `init.headers`).

## Changes
- `src/utils/constants.ts` — production app/Supabase URLs + `PLANMYPEAK_SUPABASE_ANON_KEY`
- `src/services/portConfigService.ts` — resolve production URLs from constants (no re-hardcoding)
- `src/content/mypeakAuthDetection.ts` *(new)* — pure host-detection helper
- `src/content/requestInfo.ts` *(new)* — `extractRequestInfo` (Request-object headers) + `toAbsoluteUrl` (relative→absolute)
- `src/content/mainWorldInterceptor.ts` — use the helpers; resolve URLs before detection
- `src/background/messageHandler.ts` — anon-key fallback in `VALIDATE_MY_PEAK_TOKEN`
- `public/manifest.json` — portal + new Supabase host
- Tests: new `tests/unit/content/*`, updated validation + env-indicator tests
- `openspec/changes/fix-planmypeak-prod-auth-validation/*` — full diagnosis record

## Testing
- `tsc --noEmit` clean; 35 PlanMyPeak-related unit tests pass
- Verified end-to-end on the live portal (token captured + popup authenticated)
- Pre-existing calendar/Playwright-e2e suite failures are unrelated (present on `main`)

## Scope / follow-up
Auth only. The export/data flow still targets the old `/v1/workouts/...` endpoints (the new app uses `/api/backend` and no workout-library resource) — a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)